### PR TITLE
fix: #5 question 页面图片显示异常

### DIFF
--- a/src/answer.ts
+++ b/src/answer.ts
@@ -33,6 +33,14 @@ const template = `
             window.location.replace("{{url}}");
         }
     </script>
+    <style>
+        img {
+            width: 100%;
+        }
+        figure {
+            margin: 1.4em 0;
+        }
+    </style>
 </head>
 <body style="max-width: 1000px; margin: 0 auto; padding: 0 1em 0 1em;">
     <header>
@@ -58,7 +66,6 @@ const questionTemplate = `
 
 export async function answer(id: string, redirect: boolean, env: Env): Promise<string> {
     const url = `https://api.zhihu.com/v4/answers/${id}?include=content%2Cexcerpt%2Cauthor%2Cvoteup_count%2Ccomment_count%2Cquestion%2Ccreated_time%2Cquestion.detail`;
-
     const response = await fetch(url);
     const data = (await response.json()) as Answer;
     const createdTime = new Date(data.created_time * 1000);


### PR DESCRIPTION
fix: #5
电脑端：
![](https://github.com/user-attachments/assets/5314e8de-e5bb-4f32-bda6-cec6c4e6ac7a)

手机端：
<img src="https://github.com/user-attachments/assets/06220602-01ad-446b-9cdb-e62072ecc309" width=250px></img>

临时修复，缺点：电脑版在图片为长图时依然会保持 width=100% ，基本样式正常，但观看体验不佳。

自适应的修复会在重构模板渲染部分以后进行