### PR TITLE
type checker

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -11,11 +11,13 @@ export function fixImagesAndLinks(html: string): string {
 	return result;
 }
 
-export function renderTemplate(strings: TemplateStringsArray, ...keys: string[]) {
-	return (dict: Record<string, string>) => {
+export function renderTemplate<
+	K extends readonly string[]
+>(strings: TemplateStringsArray, ...keys: K) {
+	return (dict: Record<K[number], string>) => {
 		const result = [strings[0]];
 		keys.forEach((key, i) => {
-			result.push(dict[key], strings[i + 1]);
+			result.push(dict[key as K[number]], strings[i + 1]);
 		});
 		return result.join("");
 	};


### PR DESCRIPTION
now it can type check the missing fields.

for example in question.ts

```ts
Argument of type '{ title: string; author: string; created_time: string; created_time_formatted: string; answer_count: string; content: string; redirect: string; url: string; }' is not assignable to parameter of type 'Record<"title" | "author" | "url" | "excerpt" | "redirect" | "created_time" | "created_time_formatted" | "content" | "answer_count", string>'.
  Property 'excerpt' is missing in type '{ title: string; author: string; created_time: string; created_time_formatted: string; answer_count: string; content: string; redirect: string; url: string; }' but required in type 'Record<"title" | "author" | "url" | "excerpt" | "redirect" | "created_time" | "created_time_formatted" | "content" | "answer_count", string>'.
```

so now we know `Property 'excerpt' is missing`
