### PR TITLE
fix: fix safe navigation for TransformUrl

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -105,7 +105,7 @@ export async function TransformUrl(url: string, env: Env) {
   };
 
   const transformUrl = (urlString: string, env: Env) => {
-    if (!urlString.startsWith('http')) return urlString;
+    if (!urlString?.startsWith('http')) return urlString;
 
     try {
       const questionMatch = patterns.question.exec(urlString);


### PR DESCRIPTION
sample: https://www.fxzhihu.com/question/1919318765360885981/answer/1926396181916909969

Some answers may cause this error:

<img width="649" height="136" alt="image" src="https://github.com/user-attachments/assets/7a29dd74-4161-4f82-9eba-3b6f140e5e79" />


I located the issue function. This got fixed after I added the safe navigation on my local dev. Not sure which <a> tag link caused this issue.