### PR TITLE
fix(pin): Add User-Agent to Zhihu Pin API Requests

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -190,7 +190,11 @@ const videoContentTemplate = createTemplate`
 
 export async function status(id: string, redirect: boolean, env: Env): Promise<string> {
   const url = new URL(id, `https://www.zhihu.com/api/v4/pins/`).href;
-  const response = await fetchWithCache(url);
+  const response = await fetchWithCache(url, {
+    headers: {
+      "user-agent": "Mozilla/5.0",
+    },
+  });
   const data = await response.json<Status>();
   const createdTime = new Date(data.created * 1000);
   const updatedTime = new Date(data.updated * 1000);


### PR DESCRIPTION
This fixes Zhihu pin pages that fail to render because the upstream pin API rejects FxZhihu subrequests without a User-Agent header.

## Reproduction Steps

1. Start the current worker locally with `pnpm dev -- --local --port 8787`.
2. Open `http://localhost:8787/pin/2045315909833713261?redirect=no`.
3. Alternatively, request `https://www.fxzhihu.com/pin/2045315909833713261?redirect=no` against the current deployment.

## Expected Result

FxZhihu should render the pin page HTML, including the pin title and Open Graph metadata, without redirecting users to a Zhihu anti-abuse challenge.

## Actual Result

The pin route returns an upstream Zhihu anti-abuse JSON error instead of the FxZhihu HTML page.

## Root Cause Evidence

The pin route was the only Zhihu API route that called `fetchWithCache(url)` without request headers. The answer and question APIs already send `user-agent: node`, and the article API already sends `user-agent: Mozilla/5.0`.

Local probes against `https://www.zhihu.com/api/v4/pins/2045315909833713261` showed that requests without a User-Agent returned 403, while requests with `Mozilla/5.0` returned 200. The same local worker route changed from 403 to a rendered FxZhihu page after adding the header. No cookie values or private browser state are required for this fix.

## Fix

This change adds `user-agent: Mozilla/5.0` to the pin API subrequest in `src/status.ts`. That keeps the pin route aligned with the existing article API behavior and avoids adding unnecessary authentication, signing, or broader request changes.

## Tests

1. Ran `pnpm exec vitest run`; all existing tests passed.
2. Started the worker locally with `pnpm dev -- --local --port 8787`.
3. Verified `http://localhost:8787/pin/2045315909833713261?redirect=no` returned HTTP 200 and contained the expected FxZhihu HTML.
4. Opened the same local URL in a real browser through Playwright and confirmed the page title was `暮光之眼的想法 | FxZhihu`.
